### PR TITLE
Rename GraphCDN to Stellate

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -3,7 +3,7 @@
     "version": "1.3.0",
     "manifest_version": 2,
     "description": "See whether a website is using GraphQL at a glance",
-    "homepage_url": "https://graphcdn.io",
+    "homepage_url": "https://stellate.co",
     "icons": {
       "16": "icons/icon-graphql-no-16.png",
       "48": "icons/icon-graphql-no-48.png",

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -82,7 +82,7 @@ h2 {
     opacity: var(--subline-opacity);
 }
 
-.graphcdn-logo {
+.stellate-logo {
     display: flex;
     align-items: center;
     margin-left: 8px;
@@ -92,11 +92,11 @@ h2 {
     transition: opacity 0.15s ease;
 }
 
-.graphcdn-logo:hover {
+.stellate-logo:hover {
     opacity: 1;
 }
 
-.graphcdn-logo svg {
+.stellate-logo svg {
     margin-right: 5px;
 }
 

--- a/src/ui/popup.tsx
+++ b/src/ui/popup.tsx
@@ -40,10 +40,10 @@ function Hello() {
           <span>Made by</span>
           <a
             target="_blank"
-            href="https://graphcdn.io"
-            className="graphcdn-logo"
+            href="https://stellate.co"
+            className="stellate-logo"
           >
-            <GraphCDNIcon /> GraphCDN
+            <StellateIcon /> Stellate
           </a>
         </p>
         <a
@@ -53,7 +53,7 @@ function Hello() {
               { active: true, currentWindow: true },
               function (tabs) {
                 chrome.tabs.create({
-                  url: `mailto:extension@graphcdn.io?subject=${encodeURIComponent(
+                  url: `mailto:extension@stellate.co?subject=${encodeURIComponent(
                     `False ${isGraphQL ? "positive" : "negative"} for ${
                       tabs[0]?.url || "ENTER URL HERE"
                     }`
@@ -67,7 +67,7 @@ function Hello() {
             );
           }}
           // No-JS fallback
-          href={`mailto:extension@graphcdn.io?subject=${encodeURIComponent(
+          href={`mailto:extension@stellate.co?subject=${encodeURIComponent(
             `False ${isGraphQL ? "positive" : "negative"} for ENTER URL HERE`
           )}&body=${encodeURIComponent(
             `How do you know this website actually ${
@@ -148,7 +148,7 @@ function YesGraphQLIcon(props) {
   );
 }
 
-function GraphCDNIcon(props) {
+function StellateIcon(props) {
   return (
     <svg
       {...props}


### PR DESCRIPTION
<img alt="GraphCDN is now Stellate" src=https://user-images.githubusercontent.com/1705507/173638276-c14c5acb-aa7b-4521-814b-3378a6ba1d68.gif width=300 />

As some of you may have realized, the organization of this repository has changed. Exciting times! GraphCDN is now Stellate, we have announced our Series A funding and are investing more into the future of GraphQL!

[You can read more about our renaming over at our blog](https://stellate.co/blog/graphcdn-is-now-stellate)